### PR TITLE
Show relative file paths in event view for read/edit tools

### DIFF
--- a/src/EventsList.svelte
+++ b/src/EventsList.svelte
@@ -6,8 +6,11 @@
   import { eventEmoji, eventLabel } from "./event-format";
   import IterationGroup from "./IterationGroup.svelte";
 
-  let { events, isLive = false }: { events: SessionEvent[]; isLive?: boolean } =
-    $props();
+  let {
+    events,
+    isLive = false,
+    repoPath,
+  }: { events: SessionEvent[]; isLive?: boolean; repoPath?: string } = $props();
 
   let eventsContainer: HTMLElement | undefined = $state();
   let autoScroll = $state(true);
@@ -124,7 +127,9 @@
               <span class="event-emoji"
                 >{eventEmoji(standalone.event.kind)}</span
               >
-              <span class="event-text">{eventLabel(standalone.event)}</span>
+              <span class="event-text"
+                >{eventLabel(standalone.event, repoPath)}</span
+              >
               <span class="event-time">{formatTime(standalone.event._ts)}</span>
             </button>
             {#if expandedEvents.has(i) && standalone.event.kind === "git_sync_failed" && standalone.event.error}
@@ -141,6 +146,7 @@
             {formatTime}
             {expandedEvents}
             {toggleEvent}
+            {repoPath}
             globalStartIndex={iterationGlobalStartIndices.get(iter.iteration) ??
               0}
           />
@@ -156,7 +162,9 @@
               <span class="event-emoji"
                 >{eventEmoji(standalone.event.kind)}</span
               >
-              <span class="event-text">{eventLabel(standalone.event)}</span>
+              <span class="event-text"
+                >{eventLabel(standalone.event, repoPath)}</span
+              >
               <span class="event-time">{formatTime(standalone.event._ts)}</span>
             </button>
             {#if expandedEvents.has(globalIndex) && standalone.event.kind === "git_sync_failed" && standalone.event.error}

--- a/src/IterationGroup.svelte
+++ b/src/IterationGroup.svelte
@@ -11,6 +11,7 @@
     expandedEvents,
     toggleEvent,
     globalStartIndex,
+    repoPath,
   }: {
     group: IterationGroup;
     expanded: boolean;
@@ -19,6 +20,7 @@
     expandedEvents: Set<number>;
     toggleEvent: (globalIndex: number) => void;
     globalStartIndex: number;
+    repoPath?: string;
   } = $props();
 
   function formatDuration(ms: number): string {
@@ -75,7 +77,7 @@
         >
           <button class="event-btn" onclick={() => toggleEvent(globalIndex)}>
             <span class="event-emoji">{eventEmoji(ev.kind)}</span>
-            <span class="event-text">{eventLabel(ev)}</span>
+            <span class="event-text">{eventLabel(ev, repoPath)}</span>
             <span class="event-time">{formatTime(ev._ts)}</span>
           </button>
           {#if expandedEvents.has(globalIndex) && ev.kind === "tool_use" && ev.tool_input}

--- a/src/OneShotView.svelte
+++ b/src/OneShotView.svelte
@@ -63,9 +63,7 @@
   <header>
     <h1>{repo.name} — 1-Shot</h1>
     <p class="repo-path">
-      {repo.type === "local"
-        ? repo.path
-        : `${repo.sshHost}:${repo.remotePath}`}
+      {repo.type === "local" ? repo.path : `${repo.sshHost}:${repo.remotePath}`}
     </p>
   </header>
 
@@ -126,7 +124,11 @@
     </div>
   {/if}
 
-  <EventsList events={session.events} isLive={session.running} />
+  <EventsList
+    events={session.events}
+    isLive={session.running}
+    repoPath={repo.type === "local" ? repo.path : repo.remotePath}
+  />
 
   {#if session.error}
     <section class="error">

--- a/src/RepoDetail.svelte
+++ b/src/RepoDetail.svelte
@@ -159,19 +159,27 @@
 
   let filteredBranches = $derived(
     branchSearch
-      ? branches.filter(b => b.toLowerCase().includes(branchSearch.toLowerCase()))
-      : branches
+      ? branches.filter((b) =>
+          b.toLowerCase().includes(branchSearch.toLowerCase()),
+        )
+      : branches,
   );
 
   function buildRepoPayload() {
     return repo.type === "local"
       ? { type: "local" as const, path: repo.path }
-      : { type: "ssh" as const, sshHost: repo.sshHost, remotePath: repo.remotePath };
+      : {
+          type: "ssh" as const,
+          sshHost: repo.sshHost,
+          remotePath: repo.remotePath,
+        };
   }
 
   async function fetchBranchInfo() {
     try {
-      branchInfo = await invoke<BranchInfo>("get_branch_info", { repo: buildRepoPayload() });
+      branchInfo = await invoke<BranchInfo>("get_branch_info", {
+        repo: buildRepoPayload(),
+      });
     } catch {
       branchInfo = null;
     }
@@ -179,7 +187,9 @@
 
   async function fetchBranches() {
     try {
-      branches = await invoke<string[]>("list_local_branches", { repo: buildRepoPayload() });
+      branches = await invoke<string[]>("list_local_branches", {
+        repo: buildRepoPayload(),
+      });
     } catch {
       branches = [];
     }
@@ -187,7 +197,10 @@
 
   async function handleSwitchBranch(branchName: string) {
     try {
-      await invoke("switch_branch", { repo: buildRepoPayload(), branch: branchName });
+      await invoke("switch_branch", {
+        repo: buildRepoPayload(),
+        branch: branchName,
+      });
       branchDropdownOpen = false;
       branchSearch = "";
       await fetchBranchInfo();
@@ -230,7 +243,7 @@
 
   function handleClickOutside(event: MouseEvent) {
     const target = event.target as HTMLElement;
-    if (!target.closest('.branch-selector')) {
+    if (!target.closest(".branch-selector")) {
       branchDropdownOpen = false;
       branchSearch = "";
     }
@@ -277,7 +290,12 @@
       />
     {:else}
       <h1>
-        <button class="name-edit" onclick={() => { editingName = true; }}>
+        <button
+          class="name-edit"
+          onclick={() => {
+            editingName = true;
+          }}
+        >
           {repo.name}
         </button>
       </h1>
@@ -397,15 +415,19 @@
             <button
               type="button"
               class="env-remove"
-              onclick={() => { envVars = envVars.filter((_, j) => j !== i); }}
-            >&times;</button>
+              onclick={() => {
+                envVars = envVars.filter((_, j) => j !== i);
+              }}>&times;</button
+            >
           </div>
         {/each}
         <button
           type="button"
           class="secondary env-add"
-          onclick={() => { envVars = [...envVars, { key: "", value: "" }]; }}
-        >+ Add Variable</button>
+          onclick={() => {
+            envVars = [...envVars, { key: "", value: "" }];
+          }}>+ Add Variable</button
+        >
       </fieldset>
       <div class="settings-actions">
         <button
@@ -428,22 +450,34 @@
         {#each checks as check, i}
           <details class="check-entry">
             <summary>
-              <span class="check-summary-text">{check.name || "New Check"}</span>
+              <span class="check-summary-text">{check.name || "New Check"}</span
+              >
               <button
                 type="button"
                 class="check-remove"
                 disabled={session.running}
-                onclick={(e) => { e.preventDefault(); checks = checks.filter((_, j) => j !== i); }}
-              >&times;</button>
+                onclick={(e) => {
+                  e.preventDefault();
+                  checks = checks.filter((_, j) => j !== i);
+                }}>&times;</button
+              >
             </summary>
             <div class="check-fields">
               <label>
                 Name
-                <input type="text" bind:value={check.name} disabled={session.running} />
+                <input
+                  type="text"
+                  bind:value={check.name}
+                  disabled={session.running}
+                />
               </label>
               <label>
                 Command
-                <input type="text" bind:value={check.command} disabled={session.running} />
+                <input
+                  type="text"
+                  bind:value={check.command}
+                  disabled={session.running}
+                />
               </label>
               <label>
                 When
@@ -454,11 +488,21 @@
               </label>
               <label>
                 Timeout
-                <input type="number" bind:value={check.timeoutSecs} min="1" disabled={session.running} />
+                <input
+                  type="number"
+                  bind:value={check.timeoutSecs}
+                  min="1"
+                  disabled={session.running}
+                />
               </label>
               <label>
                 Retries
-                <input type="number" bind:value={check.maxRetries} min="0" disabled={session.running} />
+                <input
+                  type="number"
+                  bind:value={check.maxRetries}
+                  min="0"
+                  disabled={session.running}
+                />
               </label>
             </div>
           </details>
@@ -467,8 +511,19 @@
           type="button"
           class="secondary check-add"
           disabled={session.running}
-          onclick={() => { checks = [...checks, { name: "", command: "", when: "each_iteration", timeoutSecs: 300, maxRetries: 1 }]; }}
-        >Add Check</button>
+          onclick={() => {
+            checks = [
+              ...checks,
+              {
+                name: "",
+                command: "",
+                when: "each_iteration",
+                timeoutSecs: 300,
+                maxRetries: 1,
+              },
+            ];
+          }}>Add Check</button
+        >
       </div>
     {/if}
   </details>
@@ -581,7 +636,11 @@
     </section>
   {/if}
 
-  <EventsList events={session.events} isLive={session.running} />
+  <EventsList
+    events={session.events}
+    isLive={session.running}
+    repoPath={repo.type === "local" ? repo.path : repo.remotePath}
+  />
 
   {#if session.error}
     <section class="error">
@@ -605,10 +664,17 @@
         <dt>Total Cost</dt>
         <dd>${session.trace.total_cost_usd.toFixed(4)}</dd>
         {#if session.trace.context_window}
-          {@const ctxPercent = Math.round((session.trace.final_context_tokens! / session.trace.context_window) * 100)}
+          {@const ctxPercent = Math.round(
+            (session.trace.final_context_tokens! /
+              session.trace.context_window) *
+              100,
+          )}
           <dt>Context</dt>
           <dd>
-            <span style="color: {sessionContextColor(ctxPercent)}" title="{session.trace.final_context_tokens!.toLocaleString()} tokens">
+            <span
+              style="color: {sessionContextColor(ctxPercent)}"
+              title="{session.trace.final_context_tokens!.toLocaleString()} tokens"
+            >
               {ctxPercent}%
             </span>
           </dd>

--- a/src/RunDetail.svelte
+++ b/src/RunDetail.svelte
@@ -139,7 +139,11 @@
         <dd>{formatDuration(trace.start_time, trace.end_time)}</dd>
         <dt>Tokens (in / out)</dt>
         <dd>
-          {(trace.total_input_tokens + trace.total_cache_read_tokens + trace.total_cache_creation_tokens).toLocaleString()} / {trace.total_output_tokens.toLocaleString()}
+          {(
+            trace.total_input_tokens +
+            trace.total_cache_read_tokens +
+            trace.total_cache_creation_tokens
+          ).toLocaleString()} / {trace.total_output_tokens.toLocaleString()}
         </dd>
         <dt>Session ID</dt>
         <dd class="mono">
@@ -152,7 +156,7 @@
     </section>
 
     <section class="events-section">
-      <EventsList {events} />
+      <EventsList {events} repoPath={trace?.repo_path} />
     </section>
   {/if}
 </main>

--- a/src/event-format.test.ts
+++ b/src/event-format.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { eventEmoji, eventLabel } from "./event-format";
+import {
+  eventEmoji,
+  eventLabel,
+  toolSummary,
+  relativePath,
+} from "./event-format";
 import type { SessionEvent } from "./types";
 
 function makeEvent(overrides: Partial<SessionEvent>): SessionEvent {
@@ -25,7 +30,9 @@ describe("eventEmoji", () => {
     });
 
     it("returns appropriate emoji for git_sync_conflict_resolve_complete", () => {
-      expect(eventEmoji("git_sync_conflict_resolve_complete")).toBe("\u{1F3C1}");
+      expect(eventEmoji("git_sync_conflict_resolve_complete")).toBe(
+        "\u{1F3C1}",
+      );
     });
 
     it("returns error emoji for git_sync_failed", () => {
@@ -213,5 +220,111 @@ describe("eventLabel", () => {
       const label = eventLabel(ev);
       expect(label).toBe("Session complete: completed");
     });
+  });
+
+  describe("tool_use with repoPath shows relative paths", () => {
+    it("shows relative path for Read tool", () => {
+      const ev = makeEvent({
+        kind: "tool_use",
+        iteration: 1,
+        tool_name: "Read",
+        tool_input: { file_path: "/home/user/myrepo/src/main.ts" },
+      });
+      const label = eventLabel(ev, "/home/user/myrepo");
+      expect(label).toBe("[1] Read: src/main.ts");
+    });
+
+    it("shows absolute path when repoPath is undefined", () => {
+      const ev = makeEvent({
+        kind: "tool_use",
+        iteration: 1,
+        tool_name: "Edit",
+        tool_input: { file_path: "/home/user/myrepo/src/main.ts" },
+      });
+      const label = eventLabel(ev);
+      expect(label).toBe("[1] Edit: /home/user/myrepo/src/main.ts");
+    });
+
+    it("shows absolute path when it does not match repoPath", () => {
+      const ev = makeEvent({
+        kind: "tool_use",
+        iteration: 1,
+        tool_name: "Write",
+        tool_input: { file_path: "/tmp/scratch.ts" },
+      });
+      const label = eventLabel(ev, "/home/user/myrepo");
+      expect(label).toBe("[1] Write: /tmp/scratch.ts");
+    });
+  });
+});
+
+describe("relativePath", () => {
+  it("strips Unix repo prefix", () => {
+    expect(relativePath("/home/user/repo/src/file.ts", "/home/user/repo")).toBe(
+      "src/file.ts",
+    );
+  });
+
+  it("strips repo prefix with trailing slash", () => {
+    expect(
+      relativePath("/home/user/repo/src/file.ts", "/home/user/repo/"),
+    ).toBe("src/file.ts");
+  });
+
+  it("returns original when no match", () => {
+    expect(relativePath("/other/path/file.ts", "/home/user/repo")).toBe(
+      "/other/path/file.ts",
+    );
+  });
+
+  it("returns original when repoPath is undefined", () => {
+    expect(relativePath("/home/user/repo/file.ts", undefined)).toBe(
+      "/home/user/repo/file.ts",
+    );
+  });
+
+  it("handles Windows-style backslash paths", () => {
+    expect(
+      relativePath(
+        "C:\\Users\\beth\\repo\\src\\file.ts",
+        "C:\\Users\\beth\\repo",
+      ),
+    ).toBe("src/file.ts");
+  });
+
+  it("handles mixed separators (SSH/WSL)", () => {
+    expect(
+      relativePath(
+        "/mnt/c/Users/beth/repo/src/file.ts",
+        "/mnt/c/Users/beth/repo",
+      ),
+    ).toBe("src/file.ts");
+  });
+
+  it("does not strip partial directory matches", () => {
+    // /home/user/repo-extra should NOT match /home/user/repo
+    expect(
+      relativePath("/home/user/repo-extra/file.ts", "/home/user/repo"),
+    ).toBe("/home/user/repo-extra/file.ts");
+  });
+});
+
+describe("toolSummary with repoPath", () => {
+  it("shows relative path for file tools", () => {
+    const ev = makeEvent({
+      kind: "tool_use",
+      tool_name: "Read",
+      tool_input: { file_path: "/home/user/repo/src/main.ts" },
+    });
+    expect(toolSummary(ev, "/home/user/repo")).toBe("Read: src/main.ts");
+  });
+
+  it("does not affect non-file tools", () => {
+    const ev = makeEvent({
+      kind: "tool_use",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+    });
+    expect(toolSummary(ev, "/home/user/repo")).toBe("Bash: npm test");
   });
 });

--- a/src/event-format.ts
+++ b/src/event-format.ts
@@ -1,5 +1,29 @@
 import type { SessionEvent } from "./types";
 
+/**
+ * Convert an absolute file path to a relative path by stripping the repo root prefix.
+ * Handles both Unix paths (/home/user/repo/src/file.ts) and Windows-style paths
+ * (C:\Users\user\repo\src\file.ts), as well as mixed separators that can appear
+ * in SSH/WSL contexts.
+ */
+export function relativePath(
+  filePath: string,
+  repoPath: string | undefined,
+): string {
+  if (!repoPath) return filePath;
+
+  // Normalise separators to forward slashes for comparison
+  const normFile = filePath.replace(/\\/g, "/");
+  const normRepo = repoPath.replace(/\\/g, "/").replace(/\/+$/, "");
+
+  if (normFile.startsWith(normRepo + "/")) {
+    return normFile.slice(normRepo.length + 1);
+  }
+
+  // No match — return the original path unchanged
+  return filePath;
+}
+
 export function eventEmoji(kind: string): string {
   switch (kind) {
     case "session_started":
@@ -61,7 +85,7 @@ export function eventEmoji(kind: string): string {
   }
 }
 
-export function toolSummary(ev: SessionEvent): string {
+export function toolSummary(ev: SessionEvent, repoPath?: string): string {
   const name = ev.tool_name ?? "unknown";
   const input = ev.tool_input;
   if (!input) return name;
@@ -72,7 +96,9 @@ export function toolSummary(ev: SessionEvent): string {
     case "Write":
     case "Edit":
     case "MultiEdit":
-      return input.file_path ? `${name}: ${input.file_path}` : name;
+      return input.file_path
+        ? `${name}: ${relativePath(String(input.file_path), repoPath)}`
+        : name;
     case "Grep":
     case "Glob":
       return input.pattern ? `${name}: ${input.pattern}` : name;
@@ -81,14 +107,14 @@ export function toolSummary(ev: SessionEvent): string {
   }
 }
 
-export function eventLabel(ev: SessionEvent): string {
+export function eventLabel(ev: SessionEvent, repoPath?: string): string {
   switch (ev.kind) {
     case "session_started":
       return `Session started: ${ev.session_id}`;
     case "iteration_started":
       return `Iteration ${ev.iteration} started`;
     case "tool_use":
-      return `[${ev.iteration}] ${toolSummary(ev)}`;
+      return `[${ev.iteration}] ${toolSummary(ev, repoPath)}`;
     case "assistant_text":
       return `[${ev.iteration}] ${ev.text}`;
     case "iteration_complete":


### PR DESCRIPTION
Strip the repo root prefix from absolute file paths displayed in event
labels for Read, Write, Edit, and MultiEdit tools. Handles Unix, Windows
backslash, and mixed-separator (SSH/WSL) paths by normalising to forward
slashes before comparison.

https://claude.ai/code/session_015h7QWuadTMKbFEzhh3FyHV