### PR TITLE
fix: resolve ESLint and Prettier lint issues across frontend

### DIFF
--- a/e2e/branch-display.test.ts
+++ b/e2e/branch-display.test.ts
@@ -154,10 +154,7 @@ test.describe("Branch display chip", () => {
     await expect(activeItem).toContainText("main");
   });
 
-  test("shows fast-forward button when behind", async ({
-    page,
-    mockTauri,
-  }) => {
+  test("shows fast-forward button when behind", async ({ page, mockTauri }) => {
     await navigateToRepo(page, mockTauri, localRepo, {
       get_branch_info: () => ({ name: "main", ahead: 0, behind: 2 }),
       list_local_branches: () => ["main", "feature/foo", "develop"],
@@ -352,10 +349,7 @@ test.describe("Branch display chip", () => {
     await expect(searchInput).toBeFocused();
   });
 
-  test("search filters branches by substring", async ({
-    page,
-    mockTauri,
-  }) => {
+  test("search filters branches by substring", async ({ page, mockTauri }) => {
     await navigateToRepo(page, mockTauri, localRepo, {
       get_branch_info: () => ({ name: "main", ahead: 0, behind: 0 }),
       list_local_branches: () => [
@@ -434,10 +428,7 @@ test.describe("Branch display chip", () => {
     await expect(emptyState).toContainText("No matching branches");
   });
 
-  test("Enter selects first matching branch", async ({
-    page,
-    mockTauri,
-  }) => {
+  test("Enter selects first matching branch", async ({ page, mockTauri }) => {
     await navigateToRepo(page, mockTauri, localRepo, {
       get_branch_info: () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/e2e/git-sync.test.ts
+++ b/e2e/git-sync.test.ts
@@ -89,11 +89,15 @@ test.describe("Git Sync settings section", () => {
     await page.locator("details.git-sync summary").click();
 
     // Enable checkbox
-    const enableCheckbox = page.locator("details.git-sync").getByRole("checkbox");
+    const enableCheckbox = page
+      .locator("details.git-sync")
+      .getByRole("checkbox");
     await expect(enableCheckbox).toBeVisible();
 
     // Model text input with placeholder "sonnet"
-    const modelInput = page.locator("details.git-sync").getByPlaceholder("sonnet");
+    const modelInput = page
+      .locator("details.git-sync")
+      .getByPlaceholder("sonnet");
     await expect(modelInput).toBeVisible();
 
     // Max push retries number input (default value 3)
@@ -104,7 +108,9 @@ test.describe("Git Sync settings section", () => {
     await expect(retriesInput).toHaveValue("3");
 
     // Conflict resolution prompt textarea
-    const textarea = page.locator("details.git-sync").getByRole("textbox", { name: /prompt|conflict/i });
+    const textarea = page
+      .locator("details.git-sync")
+      .getByRole("textbox", { name: /prompt|conflict/i });
     await expect(textarea).toBeVisible();
   });
 
@@ -144,7 +150,9 @@ test.describe("Git Sync settings section", () => {
     // Model input, retries input, and textarea should have reduced opacity
     const modelInput = gitSyncSection.getByPlaceholder("sonnet");
     const retriesInput = gitSyncSection.getByRole("spinbutton");
-    const textarea = gitSyncSection.getByRole("textbox", { name: /prompt|conflict/i });
+    const textarea = gitSyncSection.getByRole("textbox", {
+      name: /prompt|conflict/i,
+    });
 
     // Check that the fields or their containers have reduced opacity when disabled
     for (const field of [modelInput, retriesInput, textarea]) {
@@ -184,7 +192,9 @@ test.describe("Git Sync settings section", () => {
     const retriesInput = gitSyncSection.getByRole("spinbutton");
     await expect(retriesInput).toBeDisabled();
 
-    const textarea = gitSyncSection.getByRole("textbox", { name: /prompt|conflict/i });
+    const textarea = gitSyncSection.getByRole("textbox", {
+      name: /prompt|conflict/i,
+    });
     await expect(textarea).toBeDisabled();
   });
 
@@ -295,7 +305,9 @@ test.describe("Git Sync settings section", () => {
     await retriesInput.fill("5");
 
     // Fill in conflict prompt
-    const textarea = gitSyncSection.getByRole("textbox", { name: /prompt|conflict/i });
+    const textarea = gitSyncSection.getByRole("textbox", {
+      name: /prompt|conflict/i,
+    });
     await textarea.fill("Custom prompt");
 
     // Expand the settings section and click Save
@@ -306,7 +318,10 @@ test.describe("Git Sync settings section", () => {
       .click();
 
     // Navigate away by clicking the "Home" breadcrumb
-    await page.locator(".breadcrumbs").getByRole("button", { name: "Home" }).click();
+    await page
+      .locator(".breadcrumbs")
+      .getByRole("button", { name: "Home" })
+      .click();
 
     // Navigate back to the repo
     await page.getByRole("button", { name: /my-app/ }).click();

--- a/e2e/oneshot.test.ts
+++ b/e2e/oneshot.test.ts
@@ -39,9 +39,7 @@ test.describe("1-Shot navigation", () => {
   }) => {
     await navigateToRepoDetail(page, mockTauri);
 
-    await expect(
-      page.getByRole("button", { name: "1-Shot" }),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "1-Shot" })).toBeVisible();
   });
 
   test('clicking "1-Shot" navigates to the OneShotView', async ({
@@ -53,9 +51,7 @@ test.describe("1-Shot navigation", () => {
     await page.getByRole("button", { name: "1-Shot" }).click();
 
     // OneShotView should show the h1 with "1-Shot" text
-    await expect(
-      page.locator("h1", { hasText: "1-Shot" }),
-    ).toBeVisible();
+    await expect(page.locator("h1", { hasText: "1-Shot" })).toBeVisible();
 
     // The form should have Title and Prompt inputs
     await expect(page.getByText("Title")).toBeVisible();
@@ -73,9 +69,7 @@ test.describe("1-Shot navigation", () => {
 
     // Navigate to 1-Shot view
     await page.getByRole("button", { name: "1-Shot" }).click();
-    await expect(
-      page.locator("h1", { hasText: "1-Shot" }),
-    ).toBeVisible();
+    await expect(page.locator("h1", { hasText: "1-Shot" })).toBeVisible();
 
     // Click the "Home" breadcrumb link to go back
     await page.getByRole("button", { name: "Home" }).click();
@@ -90,14 +84,10 @@ test.describe("1-Shot navigation", () => {
     await page.getByRole("button", { name: "1-Shot" }).click();
 
     // The h1 should contain the repo name
-    await expect(
-      page.locator("h1", { hasText: "my-app" }),
-    ).toBeVisible();
+    await expect(page.locator("h1", { hasText: "my-app" })).toBeVisible();
 
     // The full heading should be "{repo.name} — 1-Shot"
-    await expect(
-      page.locator("h1"),
-    ).toContainText("my-app");
+    await expect(page.locator("h1")).toContainText("my-app");
   });
 });
 
@@ -137,7 +127,9 @@ test.describe("1-Shot form interaction", () => {
     await navigateToOneShotView(page, mockTauri);
 
     // The repo's model is "opus" — the Model input should have that value
-    const modelInput = page.locator('.form-section label:has-text("Model") input[type="text"]');
+    const modelInput = page.locator(
+      '.form-section label:has-text("Model") input[type="text"]',
+    );
     await expect(modelInput).toHaveValue("opus");
   });
 
@@ -148,7 +140,7 @@ test.describe("1-Shot form interaction", () => {
     await navigateToOneShotView(page, mockTauri);
 
     // Leave title empty, fill prompt
-    await page.locator('.form-section textarea').fill("Do something");
+    await page.locator(".form-section textarea").fill("Do something");
 
     const runButton = page.getByRole("button", { name: "Run" });
     await expect(runButton).toBeDisabled();
@@ -161,7 +153,9 @@ test.describe("1-Shot form interaction", () => {
     await navigateToOneShotView(page, mockTauri);
 
     // Fill title, leave prompt empty
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("My Task");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("My Task");
 
     const runButton = page.getByRole("button", { name: "Run" });
     await expect(runButton).toBeDisabled();
@@ -173,8 +167,10 @@ test.describe("1-Shot form interaction", () => {
   }) => {
     await navigateToOneShotView(page, mockTauri);
 
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("My Task");
-    await page.locator('.form-section textarea').fill("Do something important");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("My Task");
+    await page.locator(".form-section textarea").fill("Do something important");
 
     const runButton = page.getByRole("button", { name: "Run" });
     await expect(runButton).toBeEnabled();
@@ -187,7 +183,9 @@ test.describe("1-Shot form interaction", () => {
     await navigateToOneShotView(page, mockTauri);
 
     // The "Merge to main" radio should be checked by default
-    const mergeToMainRadio = page.locator('input[type="radio"][value="merge_to_main"]');
+    const mergeToMainRadio = page.locator(
+      'input[type="radio"][value="merge_to_main"]',
+    );
     await expect(mergeToMainRadio).toBeChecked();
 
     // The "Create branch" radio should not be checked
@@ -210,7 +208,8 @@ test.describe("1-Shot launch flow", () => {
         get_active_sessions: () => [],
         run_oneshot: (args: Record<string, unknown>) => {
           // Store the captured args on the window for later retrieval
-          (window as unknown as Record<string, unknown>).__capturedOneShotArgs = args;
+          (window as unknown as Record<string, unknown>).__capturedOneShotArgs =
+            args;
           return new Promise(() => {}); // never resolves to keep session running
         },
       },
@@ -222,11 +221,17 @@ test.describe("1-Shot launch flow", () => {
     await expect(page.locator("h1", { hasText: "1-Shot" })).toBeVisible();
 
     // Fill the form
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("Add auth");
-    await page.locator('.form-section textarea').fill("Implement OAuth2");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("Add auth");
+    await page.locator(".form-section textarea").fill("Implement OAuth2");
     // Change model
-    await page.locator('.form-section label:has-text("Model") input[type="text"]').fill("");
-    await page.locator('.form-section label:has-text("Model") input[type="text"]').fill("sonnet");
+    await page
+      .locator('.form-section label:has-text("Model") input[type="text"]')
+      .fill("");
+    await page
+      .locator('.form-section label:has-text("Model") input[type="text"]')
+      .fill("sonnet");
     // Select "Create branch" merge strategy
     await page.locator('input[type="radio"][value="branch"]').check();
 
@@ -235,7 +240,8 @@ test.describe("1-Shot launch flow", () => {
 
     // Retrieve the captured args from the window object
     const captured = await page.evaluate(
-      () => (window as unknown as Record<string, unknown>).__capturedOneShotArgs,
+      () =>
+        (window as unknown as Record<string, unknown>).__capturedOneShotArgs,
     );
 
     expect(captured).toBeTruthy();
@@ -272,17 +278,24 @@ test.describe("1-Shot launch flow", () => {
     await expect(page.locator(".form-section")).toBeVisible();
 
     // Fill and run
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("Task");
-    await page.locator('.form-section textarea').fill("Do work");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("Task");
+    await page.locator(".form-section textarea").fill("Do work");
     await page.getByRole("button", { name: "Run" }).click();
 
     // Emit a session event to trigger the running state in App.svelte
     await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Tauri global mock
       (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", {
         event: "session-event",
         payload: {
           repo_id: "repo-1",
-          event: { kind: "one_shot_started", title: "Task", merge_strategy: "merge_to_main" },
+          event: {
+            kind: "one_shot_started",
+            title: "Task",
+            merge_strategy: "merge_to_main",
+          },
         },
       });
     });
@@ -294,7 +307,9 @@ test.describe("1-Shot launch flow", () => {
     await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
 
     // The Run button should show "Running..." and be disabled
-    await expect(page.getByRole("button", { name: "Running..." })).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Running..." }),
+    ).toBeDisabled();
   });
 
   test("phase indicator updates as events are emitted", async ({
@@ -315,8 +330,10 @@ test.describe("1-Shot launch flow", () => {
     await expect(page.locator("h1", { hasText: "1-Shot" })).toBeVisible();
 
     // Fill and run
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("Task");
-    await page.locator('.form-section textarea').fill("Do work");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("Task");
+    await page.locator(".form-section textarea").fill("Do work");
     await page.getByRole("button", { name: "Run" }).click();
 
     const phaseIndicator = page.locator(".phase-indicator");
@@ -324,6 +341,7 @@ test.describe("1-Shot launch flow", () => {
     // Helper to emit a session event
     async function emitEvent(eventData: Record<string, unknown>) {
       await page.evaluate((evt) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Tauri global mock
         (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", {
           event: "session-event",
           payload: { repo_id: "repo-1", event: evt },
@@ -332,7 +350,11 @@ test.describe("1-Shot launch flow", () => {
     }
 
     // 1. one_shot_started -> "Starting..."
-    await emitEvent({ kind: "one_shot_started", title: "Task", merge_strategy: "merge_to_main" });
+    await emitEvent({
+      kind: "one_shot_started",
+      title: "Task",
+      merge_strategy: "merge_to_main",
+    });
     await expect(phaseIndicator).toBeVisible();
     await expect(phaseIndicator).toContainText("Starting...");
 
@@ -380,25 +402,33 @@ test.describe("1-Shot launch flow", () => {
     await expect(page.locator("h1", { hasText: "1-Shot" })).toBeVisible();
 
     // Fill and run
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("Task");
-    await page.locator('.form-section textarea').fill("Do work");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("Task");
+    await page.locator(".form-section textarea").fill("Do work");
     await page.getByRole("button", { name: "Run" }).click();
 
     const phaseIndicator = page.locator(".phase-indicator");
 
     // Emit start then failure
     await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Tauri global mock
       (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", {
         event: "session-event",
         payload: {
           repo_id: "repo-1",
-          event: { kind: "one_shot_started", title: "Task", merge_strategy: "merge_to_main" },
+          event: {
+            kind: "one_shot_started",
+            title: "Task",
+            merge_strategy: "merge_to_main",
+          },
         },
       });
     });
     await expect(phaseIndicator).toBeVisible();
 
     await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Tauri global mock
       (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", {
         event: "session-event",
         payload: {
@@ -409,6 +439,7 @@ test.describe("1-Shot launch flow", () => {
     });
 
     await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Tauri global mock
       (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", {
         event: "session-event",
         payload: {
@@ -429,7 +460,8 @@ test.describe("1-Shot launch flow", () => {
         get_active_sessions: () => [],
         run_oneshot: () => new Promise(() => {}),
         stop_session: (args: Record<string, unknown>) => {
-          (window as unknown as Record<string, unknown>).__stopSessionArgs = args;
+          (window as unknown as Record<string, unknown>).__stopSessionArgs =
+            args;
         },
       },
     });
@@ -440,17 +472,24 @@ test.describe("1-Shot launch flow", () => {
     await expect(page.locator("h1", { hasText: "1-Shot" })).toBeVisible();
 
     // Fill and run
-    await page.locator('.form-section label:has-text("Title") input[type="text"]').fill("Task");
-    await page.locator('.form-section textarea').fill("Do work");
+    await page
+      .locator('.form-section label:has-text("Title") input[type="text"]')
+      .fill("Task");
+    await page.locator(".form-section textarea").fill("Do work");
     await page.getByRole("button", { name: "Run" }).click();
 
     // Emit event to set running state
     await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Tauri global mock
       (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", {
         event: "session-event",
         payload: {
           repo_id: "repo-1",
-          event: { kind: "one_shot_started", title: "Task", merge_strategy: "merge_to_main" },
+          event: {
+            kind: "one_shot_started",
+            title: "Task",
+            merge_strategy: "merge_to_main",
+          },
         },
       });
     });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,19 +17,23 @@
   import RunDetail from "./RunDetail.svelte";
   import OneShotView from "./OneShotView.svelte";
   import { SvelteMap } from "svelte/reactivity";
-  import type { SessionTrace, SessionState, TaggedSessionEvent, BranchInfo } from "./types";
+  import type {
+    SessionTrace,
+    SessionState,
+    TaggedSessionEvent,
+    BranchInfo,
+  } from "./types";
 
   let currentView:
     | { kind: "home" }
     | { kind: "repo"; repoId: string }
     | { kind: "history"; repoId?: string }
     | { kind: "run"; repoId: string; sessionId: string; fromRepoId?: string }
-    | { kind: "oneshot"; repoId: string } =
-    $state({ kind: "home" });
+    | { kind: "oneshot"; repoId: string } = $state({ kind: "home" });
   let repos: RepoConfig[] = $state([]);
-  let sessions: SvelteMap<string, SessionState> = $state(new SvelteMap());
+  let sessions: SvelteMap<string, SessionState> = new SvelteMap();
   let latestTraces: Map<string, SessionTrace> = $state(new Map());
-  let branchInfos: SvelteMap<string, BranchInfo> = $state(new SvelteMap());
+  let branchInfos: SvelteMap<string, BranchInfo> = new SvelteMap();
   let addMode: null | "choosing" | "ssh-form" = $state(null);
   let sshHost = $state("");
   let sshRemotePath = $state("");

--- a/src/HistoryView.svelte
+++ b/src/HistoryView.svelte
@@ -226,7 +226,9 @@
           onclick={() => onSelectRun(traceRepoId(trace), trace.session_id)}
         >
           <span class="trace-date">{formatDate(trace.start_time)}</span>
-          <span class="trace-type">{trace.session_type === "one_shot" ? "1-Shot" : "Ralph Loop"}</span>
+          <span class="trace-type"
+            >{trace.session_type === "one_shot" ? "1-Shot" : "Ralph Loop"}</span
+          >
           {#if !repoId}
             <span class="trace-repo">{repoName(trace)}</span>
           {/if}

--- a/src/HomeView.svelte
+++ b/src/HomeView.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import type { RepoConfig } from "./repos";
-  import type { SessionState, SessionTrace, RepoStatus, BranchInfo } from "./types";
+  import type {
+    SessionState,
+    SessionTrace,
+    RepoStatus,
+    BranchInfo,
+  } from "./types";
   import Breadcrumbs from "./Breadcrumbs.svelte";
   import RepoCard from "./RepoCard.svelte";
 

--- a/src/OneShotView.svelte
+++ b/src/OneShotView.svelte
@@ -24,12 +24,8 @@
 
   let title = $state("");
   let prompt = $state("");
-  let model = $state("");
+  let model = $derived.writable(repo.model);
   let mergeStrategy = $state("merge_to_main");
-
-  $effect(() => {
-    model = repo.model;
-  });
 
   let phase = $derived(getPhaseFromEvents(session.events));
 

--- a/src/OneShotView.test.ts
+++ b/src/OneShotView.test.ts
@@ -168,7 +168,10 @@ describe("OneShotView buildOneShotArgs integration", () => {
     expect(args.prompt).toBe("Implement OAuth2 login");
     expect(args.model).toBe("opus");
     expect(args.mergeStrategy).toBe("merge_to_main");
-    expect(args.repo).toEqual({ type: "local", path: "/home/user/projects/my-app" });
+    expect(args.repo).toEqual({
+      type: "local",
+      path: "/home/user/projects/my-app",
+    });
   });
 
   it("builds correct args with branch merge strategy", () => {

--- a/src/RepoCard.svelte
+++ b/src/RepoCard.svelte
@@ -19,9 +19,7 @@
   } = $props();
 
   let repoFullPath = $derived(
-    repo.type === "local"
-      ? repo.path
-      : `${repo.sshHost}:${repo.remotePath}`
+    repo.type === "local" ? repo.path : `${repo.sshHost}:${repo.remotePath}`,
   );
 
   const statusColors: Record<RepoStatus, string> = {
@@ -62,7 +60,10 @@
       {/if}
       <span>${(lastTrace.total_cost_usd ?? 0).toFixed(2)}</span>
       {#if lastTrace.context_window}
-        {@const ctxPct = Math.round(((lastTrace.final_context_tokens ?? 0) / lastTrace.context_window) * 100)}
+        {@const ctxPct = Math.round(
+          ((lastTrace.final_context_tokens ?? 0) / lastTrace.context_window) *
+            100,
+        )}
         <span class="separator"> · </span>
         <span style="color: {sessionContextColor(ctxPct)}">{ctxPct}%</span>
       {/if}

--- a/src/RepoDetail.svelte
+++ b/src/RepoDetail.svelte
@@ -251,7 +251,7 @@
 
   // Fetch branch info on mount and when repo changes
   $effect(() => {
-    const _id = repo.id;
+    void repo.id;
     fetchBranchInfo();
   });
 
@@ -336,7 +336,7 @@
               Fast-forward
             </button>
           {/if}
-          {#each filteredBranches as branch}
+          {#each filteredBranches as branch (branch)}
             <button
               class="branch-item"
               class:active={branch === branchInfo.name}
@@ -397,7 +397,7 @@
       </label>
       <fieldset class="env-vars" disabled={session.running}>
         <legend>Environment Variables</legend>
-        {#each envVars as envVar, i}
+        {#each envVars as envVar, i (i)}
           <div class="env-var-row">
             <input
               type="text"
@@ -447,7 +447,7 @@
     <summary>Checks — {checks.length} configured</summary>
     {#if checksOpen}
       <div class="checks-form">
-        {#each checks as check, i}
+        {#each checks as check, i (i)}
           <details class="check-entry">
             <summary>
               <span class="check-summary-text">{check.name || "New Check"}</span

--- a/src/RepoDetail.test.ts
+++ b/src/RepoDetail.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import type { RepoConfig } from "./repos";
-import type { GitSyncConfig } from "./types";
 
 /**
  * Mirrors the saveSettings() logic in RepoDetail.svelte.
@@ -105,7 +104,10 @@ describe("createBranch ?? true defaults", () => {
 describe("buildSettingsUpdate createBranch handling", () => {
   it("includes createBranch: true in result when settings has createBranch true", () => {
     const repo = makeRepo();
-    const result = buildSettingsUpdate(repo, makeSettings({ createBranch: true }));
+    const result = buildSettingsUpdate(
+      repo,
+      makeSettings({ createBranch: true }),
+    );
     expect(result.createBranch).toBe(true);
   });
 

--- a/src/repos.test.ts
+++ b/src/repos.test.ts
@@ -520,9 +520,7 @@ describe("gitSync on repo configs", () => {
     if (result[0].type === "local") {
       expect(result[0].gitSync).toEqual(gitSync);
       expect(result[0].gitSync!.enabled).toBe(true);
-      expect(result[0].gitSync!.conflictPrompt).toBe(
-        "Fix the merge conflicts",
-      );
+      expect(result[0].gitSync!.conflictPrompt).toBe("Fix the merge conflicts");
       expect(result[0].gitSync!.model).toBe("sonnet");
       expect(result[0].gitSync!.maxPushRetries).toBe(3);
     }
@@ -696,7 +694,9 @@ describe("RepoConfig with gitSync field", () => {
     } satisfies RepoConfig;
 
     expect(repo.type).toBe("local");
-    expect((repo as RepoConfig & { gitSync?: GitSyncConfig }).gitSync).toBeUndefined();
+    expect(
+      (repo as RepoConfig & { gitSync?: GitSyncConfig }).gitSync,
+    ).toBeUndefined();
   });
 
   it("SSH RepoConfig with gitSync is valid", () => {

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -50,7 +50,11 @@ export async function loadRepos(): Promise<RepoConfig[]> {
 
 export async function addLocalRepo(path: string): Promise<RepoConfig> {
   const repos = await loadRepos();
-  const name = path.replace(/[\\/]+$/, "").split(/[\\/]/).pop() || path;
+  const name =
+    path
+      .replace(/[\\/]+$/, "")
+      .split(/[\\/]/)
+      .pop() || path;
   const repo: LocalRepoConfig = {
     type: "local",
     id: crypto.randomUUID(),


### PR DESCRIPTION
- Add eslint-disable comments for Tauri global mock `any` casts in e2e tests
- Remove unnecessary $state wrapping on SvelteMap (already reactive)
- Use $derived.writable instead of $state + $effect for model sync
- Add keyed {#each} blocks in RepoDetail.svelte
- Remove unused _id variable and GitSyncConfig import
- Apply Prettier formatting to all 13 affected files

https://claude.ai/code/session_01LKx359bos78BDpS7LSZpy8