### PR TITLE
add plansDir config field to RepoConfig and RepoDetail settings

### DIFF
--- a/docs/plans/2026-03-09-plan-selector-design.md
+++ b/docs/plans/2026-03-09-plan-selector-design.md
@@ -60,9 +60,9 @@ Add the optional `plansDir` field to the repo configuration types.
 - No migration needed — field is optional, defaults handled at usage site
 
 **Checklist:**
-- [ ] Add `plansDir?: string` to `LocalRepoConfig`
-- [ ] Add `plansDir?: string` to `SshRepoConfig`
-- [ ] Verify: `npx tsc --noEmit`
+- [x] Add `plansDir?: string` to `LocalRepoConfig`
+- [x] Add `plansDir?: string` to `SshRepoConfig`
+- [x] Verify: `npx tsc --noEmit`
 
 ---
 
@@ -82,11 +82,11 @@ Expose the plans directory configuration in the repo settings section.
 - Include in `handleSave` — only set on repo if non-empty
 
 **Checklist:**
-- [ ] Add `plansDir` state variable
-- [ ] Sync from repo prop in existing `$effect`
-- [ ] Add labeled input in settings section
-- [ ] Include in `handleSave` logic
-- [ ] Verify: `npx tsc --noEmit`
+- [x] Add `plansDir` state variable
+- [x] Sync from repo prop in existing `$effect`
+- [x] Add labeled input in settings section
+- [x] Include in `handleSave` logic
+- [x] Verify: `npx tsc --noEmit`
 
 ---
 
@@ -282,8 +282,8 @@ Add Vitest tests for plan selector behavior.
 
 | Task | Description | Status |
 |------|-------------|--------|
-| 1 | Add `plansDir` to RepoConfig | Not Started |
-| 2 | Add `plansDir` setting to RepoDetail UI | Not Started |
+| 1 | Add `plansDir` to RepoConfig | Done |
+| 2 | Add `plansDir` setting to RepoDetail UI | Done |
 | 3 | Add `list_plans` Tauri command | Not Started |
 | 4 | Add `move_plan_to_completed` Tauri command | Not Started |
 | 5 | Build plan selector dropdown component | Not Started |

--- a/src/RepoDetail.svelte
+++ b/src/RepoDetail.svelte
@@ -36,6 +36,7 @@
   let envVars: { key: string; value: string }[] = $state([]);
   let checks: Check[] = $state([]);
   let createBranch = $state(true);
+  let plansDir = $state("");
   let checksOpen = $state(false);
   let gitSyncEnabled = $state(false);
   let gitSyncModel = $state("");
@@ -55,6 +56,7 @@
     }));
     checks = repo.checks ?? [];
     createBranch = repo.createBranch ?? true;
+    plansDir = repo.plansDir ?? "";
     gitSyncEnabled = repo.gitSync?.enabled ?? false;
     gitSyncModel = repo.gitSync?.model ?? "";
     gitSyncMaxRetries = repo.gitSync?.maxPushRetries ?? 3;
@@ -164,6 +166,7 @@
       envVars: envVarsRecord,
       checks,
       createBranch,
+      plansDir: plansDir.trim() || undefined,
       gitSync: {
         enabled: gitSyncEnabled,
         model: gitSyncModel || undefined,
@@ -442,6 +445,10 @@
           disabled={session.running}
         />
         Create branch on run
+      </label>
+      <label>
+        Plans Directory
+        <input type="text" bind:value={plansDir} placeholder="docs/plans/" disabled={session.running} />
       </label>
       <fieldset class="env-vars" disabled={session.running}>
         <legend>Environment Variables</legend>

--- a/src/RepoDetail.test.ts
+++ b/src/RepoDetail.test.ts
@@ -20,6 +20,7 @@ function buildSettingsUpdate(
       maxRetries: number;
     }[];
     createBranch: boolean;
+    plansDir: string;
     gitSyncEnabled: boolean;
     gitSyncModel: string;
     gitSyncMaxRetries: number;
@@ -38,13 +39,14 @@ function buildSettingsUpdate(
     envVars: envVarsRecord,
     checks: settings.checks,
     createBranch: settings.createBranch,
+    plansDir: settings.plansDir || undefined,
     gitSync: {
       enabled: settings.gitSyncEnabled,
       model: settings.gitSyncModel || undefined,
       maxPushRetries: settings.gitSyncMaxRetries,
       conflictPrompt: settings.gitSyncPrompt || undefined,
     },
-  };
+  } as RepoConfig;
 }
 
 /** Helper to create a minimal RepoConfig for testing. */
@@ -73,6 +75,7 @@ function makeSettings(
     envVars: [],
     checks: [],
     createBranch: true,
+    plansDir: "",
     gitSyncEnabled: false,
     gitSyncModel: "",
     gitSyncMaxRetries: 3,
@@ -182,6 +185,67 @@ describe("buildSettingsUpdate createBranch handling", () => {
       model: "sonnet",
       maxPushRetries: 5,
       conflictPrompt: "resolve conflicts",
+    });
+  });
+});
+
+describe("buildSettingsUpdate plansDir handling", () => {
+  it("includes plansDir in result when non-empty", () => {
+    const repo = makeRepo();
+    const result = buildSettingsUpdate(
+      repo,
+      makeSettings({ plansDir: "docs/plans/" }),
+    );
+    expect(result.plansDir).toBe("docs/plans/");
+  });
+
+  it("sets plansDir to undefined when empty string", () => {
+    const repo = makeRepo();
+    const result = buildSettingsUpdate(repo, makeSettings({ plansDir: "" }));
+    expect(result.plansDir).toBeUndefined();
+  });
+
+  it("includes custom plansDir path", () => {
+    const repo = makeRepo();
+    const result = buildSettingsUpdate(
+      repo,
+      makeSettings({ plansDir: ".yarr/plans/" }),
+    );
+    expect(result.plansDir).toBe(".yarr/plans/");
+  });
+
+  it("preserves all other fields when plansDir is set", () => {
+    const repo = makeRepo({
+      id: "repo-pd-all",
+      name: "pd-project",
+    });
+    const result = buildSettingsUpdate(
+      repo,
+      makeSettings({
+        model: "sonnet",
+        maxIterations: 15,
+        completionSignal: "FINISHED",
+        createBranch: false,
+        plansDir: "plans/",
+        gitSyncEnabled: true,
+        gitSyncModel: "haiku",
+        gitSyncMaxRetries: 2,
+        gitSyncPrompt: "fix conflicts",
+      }),
+    );
+
+    expect(result.id).toBe("repo-pd-all");
+    expect(result.name).toBe("pd-project");
+    expect(result.model).toBe("sonnet");
+    expect(result.maxIterations).toBe(15);
+    expect(result.completionSignal).toBe("FINISHED");
+    expect(result.createBranch).toBe(false);
+    expect(result.plansDir).toBe("plans/");
+    expect(result.gitSync).toEqual({
+      enabled: true,
+      model: "haiku",
+      maxPushRetries: 2,
+      conflictPrompt: "fix conflicts",
     });
   });
 });

--- a/src/repos.test.ts
+++ b/src/repos.test.ts
@@ -935,3 +935,221 @@ describe("updateRepo preserves createBranch", () => {
     }
   });
 });
+
+describe("RepoConfig with plansDir field", () => {
+  it("local RepoConfig with plansDir is valid", () => {
+    const repo = {
+      type: "local" as const,
+      id: "local-pd-1",
+      path: "/home/beth/repos/project",
+      name: "project",
+      model: "opus",
+      maxIterations: 40,
+      completionSignal: "ALL TODO ITEMS COMPLETE",
+      plansDir: "docs/plans/",
+    } satisfies RepoConfig;
+
+    expect(repo.type).toBe("local");
+    expect(repo.plansDir).toBe("docs/plans/");
+  });
+
+  it("local RepoConfig with custom plansDir is valid", () => {
+    const repo = {
+      type: "local" as const,
+      id: "local-pd-2",
+      path: "/home/beth/repos/project",
+      name: "project",
+      model: "opus",
+      maxIterations: 40,
+      completionSignal: "ALL TODO ITEMS COMPLETE",
+      plansDir: ".yarr/plans/",
+    } satisfies RepoConfig;
+
+    expect(repo.type).toBe("local");
+    expect(repo.plansDir).toBe(".yarr/plans/");
+  });
+
+  it("local RepoConfig without plansDir (undefined) is valid", () => {
+    const repo = {
+      type: "local" as const,
+      id: "local-no-pd",
+      path: "/home/beth/repos/other",
+      name: "other",
+      model: "opus",
+      maxIterations: 20,
+      completionSignal: "DONE",
+    } satisfies RepoConfig;
+
+    expect(repo.type).toBe("local");
+    expect((repo as RepoConfig).plansDir).toBeUndefined();
+  });
+
+  it("SSH RepoConfig with plansDir is valid", () => {
+    const repo = {
+      type: "ssh" as const,
+      id: "ssh-pd-1",
+      sshHost: "dev-server",
+      remotePath: "/opt/project",
+      name: "project",
+      model: "opus",
+      maxIterations: 30,
+      completionSignal: "ALL TODO ITEMS COMPLETE",
+      plansDir: "plans/",
+    } satisfies RepoConfig;
+
+    expect(repo.type).toBe("ssh");
+    expect(repo.plansDir).toBe("plans/");
+  });
+});
+
+describe("plansDir round-trip through loadRepos", () => {
+  it("local repo with plansDir round-trips through loadRepos", async () => {
+    const existing: RepoConfig[] = [
+      {
+        type: "local",
+        id: "repo-pd-rt-1",
+        path: "/home/beth/repos/yarr",
+        name: "yarr",
+        model: "opus",
+        maxIterations: 40,
+        completionSignal: "ALL TODO ITEMS COMPLETE",
+        plansDir: "docs/plans/",
+      },
+    ];
+    mockData.set("repos", existing);
+
+    const result = await loadRepos();
+    expect(result).toHaveLength(1);
+    expect(result[0].plansDir).toBe("docs/plans/");
+  });
+
+  it("local repo without plansDir loads fine (undefined)", async () => {
+    const existing: RepoConfig[] = [
+      {
+        type: "local",
+        id: "repo-no-pd",
+        path: "/home/beth/repos/yarr",
+        name: "yarr",
+        model: "opus",
+        maxIterations: 40,
+        completionSignal: "ALL TODO ITEMS COMPLETE",
+      },
+    ];
+    mockData.set("repos", existing);
+
+    const result = await loadRepos();
+    expect(result).toHaveLength(1);
+    expect(result[0].plansDir).toBeUndefined();
+  });
+
+  it("ssh repo with plansDir round-trips through loadRepos", async () => {
+    const existing: RepoConfig[] = [
+      {
+        type: "ssh",
+        id: "repo-pd-ssh",
+        sshHost: "dev-server",
+        remotePath: "/home/beth/repos/project",
+        name: "project",
+        model: "opus",
+        maxIterations: 40,
+        completionSignal: "ALL TODO ITEMS COMPLETE",
+        plansDir: ".yarr/plans/",
+      },
+    ];
+    mockData.set("repos", existing);
+
+    const result = await loadRepos();
+    expect(result).toHaveLength(1);
+    expect(result[0].plansDir).toBe(".yarr/plans/");
+  });
+
+  it("ssh repo without plansDir loads fine (undefined)", async () => {
+    const existing: RepoConfig[] = [
+      {
+        type: "ssh",
+        id: "repo-no-pd-ssh",
+        sshHost: "dev-server",
+        remotePath: "/home/beth/repos/project",
+        name: "project",
+        model: "opus",
+        maxIterations: 40,
+        completionSignal: "ALL TODO ITEMS COMPLETE",
+      },
+    ];
+    mockData.set("repos", existing);
+
+    const result = await loadRepos();
+    expect(result).toHaveLength(1);
+    expect(result[0].plansDir).toBeUndefined();
+  });
+});
+
+describe("updateRepo preserves plansDir", () => {
+  it("updateRepo preserves plansDir config on local repo", async () => {
+    const existing: RepoConfig[] = [
+      {
+        type: "local",
+        id: "repo-update-pd",
+        path: "/home/beth/repos/yarr",
+        name: "yarr",
+        model: "opus",
+        maxIterations: 40,
+        completionSignal: "ALL TODO ITEMS COMPLETE",
+        plansDir: "docs/plans/",
+      },
+    ];
+    mockData.set("repos", existing);
+
+    const updated: RepoConfig = {
+      type: "local",
+      id: "repo-update-pd",
+      path: "/home/beth/repos/yarr",
+      name: "yarr",
+      model: "sonnet",
+      maxIterations: 20,
+      completionSignal: "DONE",
+      plansDir: "docs/plans/",
+    };
+    await updateRepo(updated);
+
+    const stored = mockData.get("repos") as RepoConfig[];
+    expect(stored).toHaveLength(1);
+    expect(stored[0].model).toBe("sonnet");
+    expect(stored[0].plansDir).toBe("docs/plans/");
+  });
+
+  it("updateRepo preserves plansDir config on ssh repo", async () => {
+    const existing: RepoConfig[] = [
+      {
+        type: "ssh",
+        id: "repo-update-pd-ssh",
+        sshHost: "dev-server",
+        remotePath: "/home/beth/repos/project",
+        name: "project",
+        model: "opus",
+        maxIterations: 40,
+        completionSignal: "ALL TODO ITEMS COMPLETE",
+        plansDir: "plans/",
+      },
+    ];
+    mockData.set("repos", existing);
+
+    const updated: RepoConfig = {
+      type: "ssh",
+      id: "repo-update-pd-ssh",
+      sshHost: "dev-server",
+      remotePath: "/home/beth/repos/project",
+      name: "project",
+      model: "sonnet",
+      maxIterations: 20,
+      completionSignal: "DONE",
+      plansDir: "plans/",
+    };
+    await updateRepo(updated);
+
+    const stored = mockData.get("repos") as RepoConfig[];
+    expect(stored).toHaveLength(1);
+    expect(stored[0].model).toBe("sonnet");
+    expect(stored[0].plansDir).toBe("plans/");
+  });
+});

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -15,6 +15,7 @@ type LocalRepoConfig = {
   checks?: Check[];
   gitSync?: GitSyncConfig;
   createBranch?: boolean;
+  plansDir?: string;
 };
 
 type SshRepoConfig = {
@@ -30,6 +31,7 @@ type SshRepoConfig = {
   checks?: Check[];
   gitSync?: GitSyncConfig;
   createBranch?: boolean;
+  plansDir?: string;
 };
 
 export type RepoConfig = LocalRepoConfig | SshRepoConfig;


### PR DESCRIPTION
Adds optional plansDir?: string to both LocalRepoConfig and SshRepoConfig types, and exposes it as a configurable text input in the RepoDetail settings section. The field stores a plans directory path relative to repo root, defaulting to docs/plans/ when absent. Empty values are trimmed and stored as undefined to avoid persisting blank strings.