### PR TITLE
Refactor assistant stream event handling to improve code clarity

### DIFF
--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -1054,7 +1054,22 @@ impl SessionRunner {
                             }
                         }
                         StreamEvent::Assistant(assistant) => {
-                            if assistant.parent_tool_use_id.is_none() {
+                            if let Some(parent_id) = &assistant.parent_tool_use_id {
+                                let parent_id = parent_id.clone();
+                                if let Some(ref usage) = assistant.message.usage {
+                                    let context_tokens =
+                                        usage.input_tokens.unwrap_or(0)
+                                        + usage.cache_read_input_tokens.unwrap_or(0)
+                                        + usage.cache_creation_input_tokens.unwrap_or(0);
+                                    let peak = sub_agent_peaks.entry(parent_id.clone()).or_insert(0);
+                                    *peak = (*peak).max(context_tokens);
+                                    self.emit(&SessionEvent::SubAgentContextUpdated {
+                                        iteration,
+                                        parent_tool_use_id: parent_id,
+                                        context_tokens,
+                                    });
+                                }
+                            } else {
                                 for block in &assistant.message.content {
                                     match block {
                                         ContentBlock::ToolUse { id, name, input } => {
@@ -1092,21 +1107,6 @@ impl SessionRunner {
                                     self.emit(&SessionEvent::ContextUpdated {
                                         iteration,
                                         context_tokens: last_context_tokens,
-                                    });
-                                }
-                            } else {
-                                let parent_id = assistant.parent_tool_use_id.as_ref().unwrap().clone();
-                                if let Some(ref usage) = assistant.message.usage {
-                                    let context_tokens =
-                                        usage.input_tokens.unwrap_or(0)
-                                        + usage.cache_read_input_tokens.unwrap_or(0)
-                                        + usage.cache_creation_input_tokens.unwrap_or(0);
-                                    let peak = sub_agent_peaks.entry(parent_id.clone()).or_insert(0);
-                                    *peak = (*peak).max(context_tokens);
-                                    self.emit(&SessionEvent::SubAgentContextUpdated {
-                                        iteration,
-                                        parent_tool_use_id: parent_id,
-                                        context_tokens,
                                     });
                                 }
                             }

--- a/src-tauri/src/ssh_orchestrator.rs
+++ b/src-tauri/src/ssh_orchestrator.rs
@@ -226,7 +226,23 @@ impl<S: SshOps> SshSessionOrchestrator<S> {
                             }
                         }
                         StreamEvent::Assistant(assistant) => {
-                            if assistant.parent_tool_use_id.is_none() {
+                            if let Some(parent_id) = &assistant.parent_tool_use_id {
+                                let parent_id = parent_id.clone();
+                                if let Some(ref usage) = assistant.message.usage {
+                                    let context_tokens =
+                                        usage.input_tokens.unwrap_or(0)
+                                        + usage.cache_read_input_tokens.unwrap_or(0)
+                                        + usage.cache_creation_input_tokens.unwrap_or(0);
+                                    tracing::debug!(iteration, %parent_id, context_tokens, "sub-agent context update");
+                                    let peak = sub_agent_peaks.entry(parent_id.clone()).or_insert(0);
+                                    *peak = (*peak).max(context_tokens);
+                                    self.emit(&SessionEvent::SubAgentContextUpdated {
+                                        iteration,
+                                        parent_tool_use_id: parent_id,
+                                        context_tokens,
+                                    });
+                                }
+                            } else {
                                 for block in &assistant.message.content {
                                     match block {
                                         ContentBlock::ToolUse { id, name, input } => {
@@ -256,22 +272,6 @@ impl<S: SshOps> SshSessionOrchestrator<S> {
                                     self.emit(&SessionEvent::ContextUpdated {
                                         iteration,
                                         context_tokens: last_context_tokens,
-                                    });
-                                }
-                            } else {
-                                let parent_id = assistant.parent_tool_use_id.as_ref().unwrap().clone();
-                                if let Some(ref usage) = assistant.message.usage {
-                                    let context_tokens =
-                                        usage.input_tokens.unwrap_or(0)
-                                        + usage.cache_read_input_tokens.unwrap_or(0)
-                                        + usage.cache_creation_input_tokens.unwrap_or(0);
-                                    tracing::debug!(iteration, %parent_id, context_tokens, "sub-agent context update");
-                                    let peak = sub_agent_peaks.entry(parent_id.clone()).or_insert(0);
-                                    *peak = (*peak).max(context_tokens);
-                                    self.emit(&SessionEvent::SubAgentContextUpdated {
-                                        iteration,
-                                        parent_tool_use_id: parent_id,
-                                        context_tokens,
                                     });
                                 }
                             }


### PR DESCRIPTION
## Summary
Refactored the conditional logic for handling assistant stream events to improve code readability and maintainability. The changes invert the condition to handle the sub-agent case first, eliminating nested else-if blocks and reducing code duplication.

## Key Changes
- **Inverted conditional logic**: Changed from `if parent_tool_use_id.is_none()` to `if let Some(parent_id) = &parent_tool_use_id` to handle the sub-agent case first
- **Improved code structure**: Moved sub-agent context update logic to the beginning of the conditional block, making the primary agent case the fallback
- **Applied consistently**: Refactored identical patterns in both `ssh_orchestrator.rs` and `session.rs` for consistency

## Implementation Details
- The functional behavior remains unchanged; this is purely a structural refactoring
- Uses Rust's `if let` pattern matching for cleaner variable binding
- Eliminates the need for `.as_ref().unwrap()` calls by binding the value upfront
- Reduces nesting depth and improves overall readability of the event handling logic

https://claude.ai/code/session_01YUBuD8VDCaBZvov9uSk1UM