### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yarr-ui",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yarr"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Yet Another Ralph Runner"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "yarr",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.yarr.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bump version to 0.1.2 in `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json`

## Release notes for v0.1.2

### Bug Fixes
- **Fix clippy unnecessary_unwrap warnings** (#14)
- **Sync default completionSignal with implementation prompt** (#13)

### Docs
- Fix clone URL, add releases link and MIT license
- Add GitHub social preview image and source files

https://claude.ai/code/session_01Lu1f4srm4pvCcQKrGY9Psq